### PR TITLE
Fix `strnlen` error in some MinGW versions.

### DIFF
--- a/packcc.c
+++ b/packcc.c
@@ -44,11 +44,12 @@
 
 #ifndef _MSC_VER
 #if defined __GNUC__ && defined _WIN32 /* MinGW */
-static size_t strnlen(const char *str, size_t maxlen) {
+static size_t my_strnlen(const char *str, size_t maxlen) {
     size_t i;
     for (i = 0; str[i] && i < maxlen; i++);
     return i;
 }
+#define strnlen my_strnlen
 #else
 #include <unistd.h> /* for strnlen() */
 #endif


### PR DESCRIPTION
I got the following error, which the above workaround fixes (by eliminating a symbol naming conflict):

```
$ gcc -O3 -static-libgcc -static -opackcc packcc.c
packcc.c:47:15: error: static declaration of 'strnlen' follows non-static declaration
 static size_t strnlen(const char *str, size_t maxlen) {
               ^~~~~~~
In file included from packcc.c:42:0:
C:/Devel/MinGW/x86_64-win32/x86_64-w64-mingw32/include/string.h:65:18: note: previous declaration of 'strnlen' was here
   size_t __cdecl strnlen(const char *_Str,size_t _MaxCount);
```

```
$ gcc --version
gcc (x86_64-win32-seh-rev0, Built by MinGW-W64 project) 6.4.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```